### PR TITLE
Support spaces in path to java executable

### DIFF
--- a/distribution/src/main/resources/bin/plugin
+++ b/distribution/src/main/resources/bin/plugin
@@ -110,4 +110,4 @@ fi
 HOSTNAME=`hostname | cut -d. -f1`
 export HOSTNAME
 
-eval "$JAVA" -client -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginManagerCliParser $args
+eval "\"$JAVA\"" -client -Delasticsearch -Des.path.home="\"$ES_HOME\"" $properties -cp "\"$ES_HOME/lib/*\"" org.elasticsearch.plugins.PluginManagerCliParser $args


### PR DESCRIPTION
On my Mac Java is installed in `/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home`.

When I type `which java` I get `/usr/bin/java`, but the `plugin` script prefers to look in `$JAVA_HOME`.

When `eval` is called we need two sets of quotes in order to protect the space.

Without this patch I get this output:

```
$ plugin -l
/usr/local/bin/plugin: line 109: /Library/Internet: No such file or directory
```

With the patch, I get:

```
$ plugin -l
Installed plugins:
    - No plugin detected in /usr/local/var/lib/elasticsearch/plugins
```
